### PR TITLE
Remove daemon flags of threads

### DIFF
--- a/connection.py
+++ b/connection.py
@@ -172,7 +172,6 @@ class MultiProcessWorkers:
         for i in range(self.num_receivers):
             self.threads.append(threading.Thread(target=self._receiver, args=(i,)))
         for thread in self.threads:
-            thread.daemon = True
             thread.start()
 
     def _sender(self):
@@ -257,7 +256,6 @@ class MultiThreadWorkers:
         for i in range(self.num):
             conn = LocalConnection(self)
             self.threads.append(threading.Thread(target=self.func, args=(conn, i)))
-            self.threads[-1].daemon = True
             self.threads[-1].start()
 
 
@@ -274,7 +272,6 @@ class QueueCommunicator:
             threading.Thread(target=self._recv_thread),
         ]
         for thread in self.threads:
-            thread.daemon = True
             thread.start()
 
     def shutdown(self):

--- a/train.py
+++ b/train.py
@@ -604,7 +604,6 @@ class Learner:
             if self.args['remote']:
                 self.threads.append(threading.Thread(target=self.entry_server))
             for thread in self.threads:
-                thread.daemon = True
                 thread.start()
             # open generator, evaluator
             self.workers.run()

--- a/worker.py
+++ b/worker.py
@@ -124,8 +124,11 @@ class Gather(QueueCommunicator):
 
 
 def gather_loop(args, conn, gaid):
-    gather = Gather(args, conn, gaid)
-    gather.run()
+    try:
+        gather = Gather(args, conn, gaid)
+        gather.run()
+    finally:
+        gather.shutdown()
 
 
 class Workers(QueueCommunicator):
@@ -146,7 +149,6 @@ class Workers(QueueCommunicator):
                 print('finished worker server')
             # use super class's thread list
             self.threads.append(threading.Thread(target=worker_server, args=(9998,)))
-            self.threads[-1].daemon = True
             self.threads[-1].start()
         else:
             # open local connections


### PR DESCRIPTION
Opening threads with `daemon=True` is not necessary.