### PR TITLE
Change tuple with list in ConvLSTMCell.init_hidden()

### DIFF
--- a/model.py
+++ b/model.py
@@ -173,10 +173,10 @@ class ConvLSTMCell(nn.Module):
         )
 
     def init_hidden(self, input_size, batch_size):
-        return tuple(
+        return [
             torch.zeros(*batch_size, self.hidden_dim, *input_size),
             torch.zeros(*batch_size, self.hidden_dim, *input_size),
-        )
+        ]
 
     def forward(self, input_tensor, cur_state):
         h_cur, c_cur = cur_state


### PR DESCRIPTION
Resolve `TypeError: tuple() takes at most 1 argument (2 given)`.

`python train.py` is passed with the environments, TicTacToe and Geister.