### PR TITLE
FIX: get player indices of model_id from env.players()

### DIFF
--- a/environments/tictactoe.py
+++ b/environments/tictactoe.py
@@ -97,7 +97,7 @@ class Environment(BaseEnvironment):
         return 3 * 3
 
     def players(self):
-        return [0, 1]
+        return ['Player1', 'Player2']
 
     def observation(self, player=None):
         # input feature for neural nets

--- a/environments/tictactoe.py
+++ b/environments/tictactoe.py
@@ -97,7 +97,7 @@ class Environment(BaseEnvironment):
         return 3 * 3
 
     def players(self):
-        return ['Player1', 'Player2']
+        return [0, 1]
 
     def observation(self, player=None):
         # input feature for neural nets

--- a/train.py
+++ b/train.py
@@ -527,7 +527,7 @@ class Learner:
                         if args['role'] == 'g':
                             # genatation configuration
                             args['player'] = self.env.players()[self.num_episodes % len(self.env.players())]
-                            for p in range(2):
+                            for p in self.env.players():
                                 args['model_id'][p] = self.model_era
                             self.num_episodes += 1
                             if self.num_episodes % 100 == 0:
@@ -536,7 +536,7 @@ class Learner:
                         elif args['role'] == 'e':
                             # evaluation configuration
                             args['player'] = self.env.players()[self.num_results % len(self.env.players())]
-                            for p in range(2):
+                            for p in self.env.players():
                                 if p == args['player']:
                                     args['model_id'][p] = self.model_era
                                 else:


### PR DESCRIPTION
Fix the bug that train.py raises an error when env.player() returns the player list of string like ['Player1', 'Player2'].